### PR TITLE
Fix WPS 'pixie dust' vulnerability

### DIFF
--- a/core/rtw_tdls.c
+++ b/core/rtw_tdls.c
@@ -16,6 +16,7 @@
 
 #include <drv_types.h>
 #include <hal_data.h>
+#include <linux/random.h>
 
 #ifdef CONFIG_TDLS
 #define ONE_SEC 	1000 /* 1000 ms */
@@ -2816,6 +2817,7 @@ void rtw_build_tdls_setup_req_ies(_adapter *padapter, struct xmit_frame *pxmitfr
 			time = rtw_get_current_time();
 			_rtw_memcpy(&ptdls_sta->SNonce[4 * i], (u8 *)&time, 4);
 		}
+		get_random_bytes(&ptdls_sta->SNonce, 32);
 	}
 
 	pframe_head = pframe;	/* For rtw_tdls_set_ht_cap() */
@@ -2892,6 +2894,7 @@ void rtw_build_tdls_setup_rsp_ies(_adapter *padapter, struct xmit_frame *pxmitfr
 			time = rtw_get_current_time();
 			_rtw_memcpy(&ptdls_sta->ANonce[4 * k], (u8 *)&time, 4);
 		}
+		get_random_bytes(&ptdls_sta->ANonce, 32);
 	}
 
 	pframe_head = pframe;


### PR DESCRIPTION
from https://github.com/Azq2/rtl8189ES_linux/commit/438b69d09795d7a50f0faf8c4c651cf4bd7a9b2c

tested on rtl8189ftv successfully.